### PR TITLE
Fix slide event handling and add specialization modals

### DIFF
--- a/components/Modal.js
+++ b/components/Modal.js
@@ -1,0 +1,33 @@
+import { motion, AnimatePresence } from 'framer-motion';
+
+export default function Modal({ open, onClose, children }) {
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="fixed inset-0 bg-black/70 flex items-center justify-center z-50"
+          onClick={onClose}
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.div
+            onClick={(e) => e.stopPropagation()}
+            className="relative bg-black border border-accent rounded-lg p-4 w-full max-w-xl max-h-[80vh] overflow-y-auto"
+            initial={{ scale: 0.9, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.9, opacity: 0 }}
+          >
+            <button
+              className="absolute top-2 right-2 text-red-400 border border-red-400 rounded px-2"
+              onClick={onClose}
+            >
+              ✕
+            </button>
+            {children}
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/components/slides/Year34Slide.js
+++ b/components/slides/Year34Slide.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import Modal from '../Modal';
 import { motion } from 'framer-motion';
 import TerminalWindow from '../TerminalWindow';
 import TypeWriter from '../TypeWriter';
@@ -27,14 +28,22 @@ const alumniStories = [
 ];
 
 export default function Year34Slide() {
-  const [active, setActive] = useState(null);
+  const [selected, setSelected] = useState(null);
+  const [tab, setTab] = useState('overview');
+  const [filter, setFilter] = useState('');
+  const [sortKey, setSortKey] = useState('name');
 
-  const toggle = (id) => {
-    setActive((prev) => (prev === id ? null : id));
+  const openModal = (spec) => {
+    setSelected(spec);
+    setTab('overview');
   };
 
+  const filtered = specializations
+    .filter((s) => s.name.toLowerCase().includes(filter.toLowerCase()))
+    .sort((a, b) => (a[sortKey] > b[sortKey] ? 1 : -1));
+
   return (
-    <div className="slide" onClick={() => {}}>
+    <div className="slide">
       {/* SECTION 1 - HEADER */}
       <TerminalWindow title="specialization_selector.py" className="space-y-4">
         <TypeWriter text="🎯 ปี 3-4: Choose Your Tech Stack & Specialization..." />
@@ -51,35 +60,38 @@ export default function Year34Slide() {
 
       {/* SECTION 2-7 - SPECIALIZATION CARDS */}
       <div className="mt-4 space-y-2 max-h-[50vh] overflow-y-auto p-2">
-        {specializations.map((spec) => (
+        <div className="flex items-center gap-2 mb-2">
+          <input
+            type="text"
+            placeholder="Filter"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            className="flex-1 bg-black/50 border border-accent rounded px-2 py-1 text-sm"
+          />
+          <select
+            value={sortKey}
+            onChange={(e) => setSortKey(e.target.value)}
+            className="bg-black/50 border border-accent rounded px-2 py-1 text-sm"
+          >
+            <option value="name">Sort A-Z</option>
+            <option value="id">Sort by ID</option>
+          </select>
+        </div>
+        {filtered.map((spec) => (
           <motion.div
             key={spec.id}
             className="bg-black/40 border rounded p-3 cursor-pointer"
             whileHover={{ scale: 1.02 }}
-            onClick={() => toggle(spec.id)}
+            onClick={(e) => {
+              e.stopPropagation();
+              openModal(spec);
+            }}
           >
             <div className="flex items-center space-x-2">
               <span className="text-xl">{spec.icon}</span>
               <h3 className="font-semibold text-lg">{spec.name}</h3>
               <span className="text-sm text-gray-400">{spec.tagline}</span>
             </div>
-            {active === spec.id && (
-              <motion.div
-                className="mt-2 text-sm space-y-1"
-                initial={{ opacity: 0 }}
-                animate={{ opacity: 1 }}
-              >
-                <p>{spec.description}</p>
-                <div className="grid grid-cols-2 gap-1">
-                  {Object.entries(spec.techStack).map(([k, list]) => (
-                    <div key={k}>
-                      <h4 className="font-semibold text-accent text-xs">{k}</h4>
-                      <p className="text-xs">{list.join(', ')}</p>
-                    </div>
-                  ))}
-                </div>
-              </motion.div>
-            )}
           </motion.div>
         ))}
       </div>
@@ -132,6 +144,72 @@ export default function Year34Slide() {
         <p>Job growth projections show continual increase across all tracks.</p>
         <p>Cloud, AI, and mobile technologies are leading the next decade.</p>
       </div>
+      <Modal open={!!selected} onClose={() => setSelected(null)}>
+        {selected && (
+          <div className="space-y-3">
+            <h3 className="text-xl font-bold flex items-center gap-2">
+              <span>{selected.icon}</span> {selected.name}
+            </h3>
+            <div className="flex gap-2">
+              {['overview', 'projects', 'careers', 'learning'].map((t) => (
+                <button
+                  key={t}
+                  onClick={() => setTab(t)}
+                  className={`px-2 py-1 border rounded text-sm ${tab === t ? 'bg-accent text-black' : 'bg-black/50 border-accent'}`}
+                >
+                  {t.charAt(0).toUpperCase() + t.slice(1)}
+                </button>
+              ))}
+            </div>
+            {tab === 'overview' && (
+              <div className="text-sm space-y-1">
+                <p>{selected.description}</p>
+                <div className="grid grid-cols-2 gap-1">
+                  {Object.entries(selected.techStack).map(([k, list]) => (
+                    <div key={k}>
+                      <h4 className="font-semibold text-accent text-xs">{k}</h4>
+                      <p className="text-xs">{list.join(', ')}</p>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            {tab === 'projects' && (
+              <div className="space-y-1 text-sm">
+                {selected.projectExamples?.map((p) => (
+                  <div key={p.title} className="border-b pb-1">
+                    <div className="font-semibold">{p.title}</div>
+                    <p className="text-xs">{p.description}</p>
+                    <p className="text-xs text-gray-400">Tech: {p.tech.join(', ')}</p>
+                  </div>
+                ))}
+              </div>
+            )}
+            {tab === 'careers' && (
+              <div className="space-y-1 text-sm">
+                {selected.careerPaths?.map((c) => (
+                  <div key={c.title} className="flex justify-between text-xs border-b pb-1">
+                    <span>{c.title}</span>
+                    <span className="text-gray-400">{c.salary} THB – {c.demand}</span>
+                  </div>
+                ))}
+              </div>
+            )}
+            {tab === 'learning' && (
+              <div className="text-sm space-y-1">
+                {selected.learningPath && (
+                  <>
+                    <h4 className="font-semibold text-accent text-xs">Year 3</h4>
+                    <p className="text-xs">{selected.learningPath.year3.join(', ')}</p>
+                    <h4 className="font-semibold text-accent text-xs mt-2">Year 4</h4>
+                    <p className="text-xs">{selected.learningPath.year4.join(', ')}</p>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+      </Modal>
     </div>
   );
 }

--- a/hooks/useSlideNavigation.js
+++ b/hooks/useSlideNavigation.js
@@ -27,7 +27,5 @@ export function useSlideNavigation() {
     return () => window.removeEventListener('keydown', handleKey);
   }, [nextSlide, prevSlide]);
 
-  const handleClick = () => nextSlide();
-
-  return { current, nextSlide, prevSlide, handleClick };
+  return { current, nextSlide, prevSlide };
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -4,7 +4,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { useEffect, useState } from 'react';
 
 export default function Home() {
-  const { current, handleClick } = useSlideNavigation();
+  const { current } = useSlideNavigation();
   const SlideComponent = slides[current] || slides[0];
   const [loading, setLoading] = useState(true);
 
@@ -50,7 +50,7 @@ export default function Home() {
   };
 
   return (
-    <div onClick={handleClick} className="w-full h-full relative">
+    <div className="w-full h-full relative">
       <AnimatePresence mode="wait">
         <motion.div
           key={current}


### PR DESCRIPTION
## Summary
- remove slide click navigation to avoid accidental slide changes
- create generic `Modal` component
- add modal-based specialization details with tabs
- filter and sort specialization cards
- remove unused navigation handler

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a7d968c8c832faa380c2de35e7041